### PR TITLE
check `typeof cm.hasFocus` before calling to avoid uncaught TypeError

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1,88 +1,94 @@
 import { Plugin, Editor } from 'obsidian';
 
 export default class CursorGoaway extends Plugin {
-	private currentKeydownHandler?: (e: KeyboardEvent) => void;
-	
-	async onload() {
-		this.registerEvent(
-			this.app.workspace.on('file-open', (file) => {
-				let startTime: number;
-				let isBlurring = false;
-				
-				const blurEditor = () => {
-					this.app.workspace.activeEditor?.editor?.blur();
-					
-					if (performance.now() - startTime < 500) {
-						requestAnimationFrame(blurEditor)
-					} else {
-						isBlurring = false;
-					}
-				}
+    private currentKeydownHandler?: (e: KeyboardEvent) => void;
+    private blurFrameId?: number;
 
-				// Always cleanup any previous one-time handler when opening a new file
-				this.cleanupKeydownHandler();
+    async onload() {
+        this.registerEvent(
+            this.app.workspace.on('file-open', (file) => {
+                // Always cleanup any previous one-time handler when opening a new file
+                this.cleanup();
 
-				// when toggle to the md file, blur the page in 500ms to avoid break the preview style	
-				if (file?.extension === 'md') {
-					startTime = performance.now();
-					isBlurring = true;
-					requestAnimationFrame(blurEditor);
-					
-					const onKeyDown = (e: KeyboardEvent) => {
-						if (e.key !== 'ArrowDown') return;
-						const activeFile = this.app.workspace.getActiveFile();
-						// Only react if the same file is still active
-						if (activeFile?.path !== file.path) return this.cleanupKeydownHandler();
-						// Ignore ArrowDown while blur cycle is active
-						if (isBlurring) return;
-						
-						// Check if editor already has focus (user is already editing)
-						const editor = this.app.workspace.activeEditor?.editor as Editor | undefined;
-						if (editor) {
-							// Try to access the CodeMirror instance to check focus state
-							// @ts-ignore - accessing internal cm property
-							const cm = editor.cm;
-							if (cm && (typeof cm.hasFocus === "function" ? cm.hasFocus() : cm.hasFocus)) {
-								// Editor already has focus, don't jump to top
-								return this.cleanupKeydownHandler();
-							}
-						}
-						
-						// Fallback: check if activeElement is within the editor container
-						const activeElement = document.activeElement;
-						const editorContainer = activeElement?.closest('.cm-editor, .cm-content, .markdown-source-view');
-						if (editorContainer) {
-							// Editor already focused, don't jump to top
-							return this.cleanupKeydownHandler();
-						}
-						
-						// Editor not focused yet, jump to top and focus
-						e.preventDefault();
-						if (editor) {
-							try { editor.focus(); } catch (err) { console.debug('focus() failed', err); }
-							editor.setCursor(0, 0);
-						}
-						this.cleanupKeydownHandler();
-					};
-					document.addEventListener('keydown', onKeyDown, true);
-					this.currentKeydownHandler = onKeyDown;
-				}
-			})
-		)
-		
-	}
+                // Return early if not Markdown
+                if (file?.extension !== 'md') return;
 
-	/**
-	 * cleanup the keydown handler
-	 */
-	cleanupKeydownHandler() {
-		if (this.currentKeydownHandler) {
-			document.removeEventListener('keydown', this.currentKeydownHandler, true);
-			this.currentKeydownHandler = undefined;
-		}
-	}
+                // When toggle to the Markdown file, blur the page in 500ms to avoid break the preview style
+                let startTime = performance.now();
+                let isBlurring = true;
 
-	onunload() {
-		this.cleanupKeydownHandler();
-	}
+                const blurEditor = () => {
+                    this.app.workspace.activeEditor?.editor?.blur();
+                    if (performance.now() - startTime < 500) {
+                        this.blurFrameId = requestAnimationFrame(blurEditor);
+                    } else {
+                        isBlurring = false;
+                        this.blurFrameId = undefined;
+                    }
+                };
+                
+                this.blurFrameId = requestAnimationFrame(blurEditor);
+
+                const onKeyDown = (e: KeyboardEvent) => {
+                    if (e.key !== 'ArrowDown') return;
+                    
+                    const activeFile = this.app.workspace.getActiveFile();
+                    // Only react if the same file is still active
+                    if (activeFile?.path !== file.path) return this.cleanup();
+                    
+                    // Ignore ArrowDown while blur cycle is active
+                    if (isBlurring) return;
+
+                    // Check if editor already has focus (user is already editing)
+                    const editor = this.app.workspace.activeEditor?.editor as Editor | undefined;
+                    if (editor) {
+                        // Try to access the CodeMirror instance to check focus state
+                        // @ts-ignore - accessing internal cm property
+                        const cm = editor.cm;
+                        if (cm && (typeof cm.hasFocus === "function" ? cm.hasFocus() : cm.hasFocus)) {
+                            // Editor already has focus, don't jump to top
+                            return this.cleanup();
+                        }
+                    }
+
+                    // Fallback: check if activeElement is within the editor container
+                    const activeElement = document.activeElement;
+                    const editorContainer = activeElement?.closest('.cm-editor, .cm-content, .markdown-source-view');
+                    if (editorContainer) {
+                        // Editor already focused, don't jump to top
+                        return this.cleanup();
+                    }
+
+                    // Editor not focused yet, jump to top and focus
+                    e.preventDefault();
+                    if (editor) {
+                        try { editor.focus(); } catch (err) { console.debug('focus() failed', err); }
+                        editor.setCursor(0, 0);
+                    }
+                    this.cleanup();
+                };
+
+                document.addEventListener('keydown', onKeyDown, true);
+                this.currentKeydownHandler = onKeyDown;
+            })
+        );
+    }
+
+    /**
+     * cleanup the keydown handler and animation frame
+     */
+    cleanup() {
+        if (this.currentKeydownHandler) {
+            document.removeEventListener('keydown', this.currentKeydownHandler, true);
+            this.currentKeydownHandler = undefined;
+        }
+        if (this.blurFrameId !== undefined) {
+            cancelAnimationFrame(this.blurFrameId);
+            this.blurFrameId = undefined;
+        }
+    }
+
+    onunload() {
+        this.cleanup();
+    }
 }

--- a/main.ts
+++ b/main.ts
@@ -42,7 +42,7 @@ export default class CursorGoaway extends Plugin {
 							// Try to access the CodeMirror instance to check focus state
 							// @ts-ignore - accessing internal cm property
 							const cm = editor.cm;
-							if (cm && cm.hasFocus && cm.hasFocus()) {
+							if (cm && (typeof cm.hasFocus === "function" ? cm.hasFocus() : cm.hasFocus)) {
 								// Editor already has focus, don't jump to top
 								return this.cleanupKeydownHandler();
 							}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "obsidian-plugin-cursor-goaway",
-	"version": "1.3.0",
+	"version": "1.5.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "obsidian-plugin-cursor-goaway",
-			"version": "1.3.0",
+			"version": "1.5.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^16.11.6",
@@ -743,16 +743,21 @@
 			}
 		},
 		"node_modules/ajv": {
-			"version": "6.12.6",
-			"resolved": "https://registry.npmmirror.com/ajv/-/ajv-6.12.6.tgz",
-			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+			"integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
 			"dev": true,
+			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
 				"json-schema-traverse": "^0.4.1",
 				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
 			}
 		},
 		"node_modules/ansi-regex": {
@@ -802,10 +807,11 @@
 			"peer": true
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmmirror.com/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
 			"dev": true,
+			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0",
@@ -813,12 +819,13 @@
 			}
 		},
 		"node_modules/braces": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmmirror.com/braces/-/braces-3.0.2.tgz",
-			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"fill-range": "^7.0.1"
+				"fill-range": "^7.1.1"
 			},
 			"engines": {
 				"node": ">=8"
@@ -885,10 +892,11 @@
 			"peer": true
 		},
 		"node_modules/cross-spawn": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmmirror.com/cross-spawn/-/cross-spawn-7.0.3.tgz",
-			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
 			"dev": true,
+			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"path-key": "^3.1.0",
@@ -1268,10 +1276,11 @@
 			}
 		},
 		"node_modules/fill-range": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmmirror.com/fill-range/-/fill-range-7.0.1.tgz",
-			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"to-regex-range": "^5.0.1"
 			},
@@ -1309,10 +1318,11 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.2.9",
-			"resolved": "https://registry.npmmirror.com/flatted/-/flatted-3.2.9.tgz",
-			"integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+			"integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
 			"dev": true,
+			"license": "ISC",
 			"peer": true
 		},
 		"node_modules/fs.realpath": {
@@ -1480,9 +1490,10 @@
 		},
 		"node_modules/is-number": {
 			"version": "7.0.0",
-			"resolved": "https://registry.npmmirror.com/is-number/-/is-number-7.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.12.0"
 			}
@@ -1505,10 +1516,11 @@
 			"peer": true
 		},
 		"node_modules/js-yaml": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmmirror.com/js-yaml/-/js-yaml-4.1.0.tgz",
-			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
 			"dev": true,
+			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"argparse": "^2.0.1"
@@ -1604,12 +1616,13 @@
 			}
 		},
 		"node_modules/micromatch": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmmirror.com/micromatch/-/micromatch-4.0.5.tgz",
-			"integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"braces": "^3.0.2",
+				"braces": "^3.0.3",
 				"picomatch": "^2.3.1"
 			},
 			"engines": {
@@ -1617,10 +1630,11 @@
 			}
 		},
 		"node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmmirror.com/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
+			"license": "ISC",
 			"peer": true,
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
@@ -1772,12 +1786,16 @@
 			}
 		},
 		"node_modules/picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmmirror.com/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/prelude-ls": {
@@ -1956,9 +1974,10 @@
 		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
-			"resolved": "https://registry.npmmirror.com/to-regex-range/-/to-regex-range-5.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
 			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"is-number": "^7.0.0"
 			},


### PR DESCRIPTION
Fixes the error by checking `typeof cm.hasFocus` before invoking it, falling back to reading it as a boolean when it is not a function.

Also fixes security vulnerabilities by the way.

Third commit is vibe-coded, aims to improve performance, feel free to exclude it.

Closes #7